### PR TITLE
Use defaults for unset monitor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,9 @@ AzureProvider supports the following healthcheck options for dynamic records (fr
 
 | Key | Description | Default |
 |--|--|--|
-| interval_in_seconds | This value specifies how often an endpoint is checked for its health from a Traffic Manager probing agent. You can specify two values here: 30 seconds (normal probing) and 10 seconds (fast probing). If no values are provided, the profile sets to a default value of 30 seconds. Visit the [Traffic Manager Pricing](https://azure.microsoft.com/pricing/details/traffic-manager) page to learn more about fast probing pricing. | 30 |
-| timeout_in_seconds | This property specifies the amount of time the Traffic Manager probing agent should wait before considering a health probe check to an endpoint a failure. If the Probing Interval is set to 30 seconds, then you can set the Timeout value between 5 and 10 seconds. If no value is specified, it uses a default value of 10 seconds. If the Probing Interval is set to 10 seconds, then you can set the Timeout value between 5 and 9 seconds. If no Timeout value is specified, it uses a default value of 9 seconds. | 10 or 9 |
-| tolerated_number_of_failures | This value specifies how many failures a Traffic Manager probing agent tolerates before marking that endpoint as unhealthy. Its value can range between 0 and 9. A value of 0 means a single monitoring failure can cause that endpoint to be marked as unhealthy. If no value is specified, it uses the default value of 3. | 3 |
-
-
+| interval | This value specifies how often an endpoint is checked for its health from a Traffic Manager probing agent. You can specify two values here: 30 seconds (normal probing) and 10 seconds (fast probing). If no values are provided, the profile sets to a default value of 30 seconds. Visit the [Traffic Manager Pricing](https://azure.microsoft.com/pricing/details/traffic-manager) page to learn more about fast probing pricing. | 30 |
+| timeout | This property specifies the amount of time the Traffic Manager probing agent should wait before considering a health probe check to an endpoint a failure. If the Probing Interval is set to 30 seconds, then you can set the Timeout value between 5 and 10 seconds. If no value is specified, it uses a default value of 10 seconds. If the Probing Interval is set to 10 seconds, then you can set the Timeout value between 5 and 9 seconds. If no Timeout value is specified, it uses a default value of 9 seconds. | 10 or 9 |
+| num_failures | This value specifies how many failures a Traffic Manager probing agent tolerates before marking that endpoint as unhealthy. Its value can range between 0 and 9. A value of 0 means a single monitoring failure can cause that endpoint to be marked as unhealthy. If no value is specified, it uses the default value of 3. | 3 |
 
 ```
 ---

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -285,22 +285,22 @@ def _pool_traffic_manager_name(pool, record):
     return f'{prefix}-pool-{pool}'
 
 
-def _healthcheck_tolerated_number_of_failures(record):
+def _healthcheck_num_failures(record):
     return record._octodns.get('azuredns', {}) \
         .get('healthcheck', {}) \
-        .get('tolerated_number_of_failures')
+        .get('num_failures')
 
 
-def _healthcheck_interval_in_seconds(record):
+def _healthcheck_interval(record):
     return record._octodns.get('azuredns', {}) \
         .get('healthcheck', {}) \
-        .get('interval_in_seconds')
+        .get('interval')
 
 
-def _healthcheck_timeout_in_seconds(record):
+def _healthcheck_timeout(record):
     return record._octodns.get('azuredns', {}) \
         .get('healthcheck', {}) \
-        .get('timeout_in_seconds')
+        .get('timeout')
 
 
 def _get_monitor(record):
@@ -308,10 +308,9 @@ def _get_monitor(record):
         protocol=record.healthcheck_protocol,
         port=record.healthcheck_port,
         path=record.healthcheck_path,
-        interval_in_seconds=_healthcheck_interval_in_seconds(record),
-        timeout_in_seconds=_healthcheck_timeout_in_seconds(record),
-        tolerated_number_of_failures=
-        _healthcheck_tolerated_number_of_failures(record),
+        interval_in_seconds=_healthcheck_interval(record),
+        timeout_in_seconds=_healthcheck_timeout(record),
+        tolerated_number_of_failures=_healthcheck_num_failures(record),
     )
     host = record.healthcheck_host()
     if host:

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -288,19 +288,20 @@ def _pool_traffic_manager_name(pool, record):
 def _healthcheck_num_failures(record):
     return record._octodns.get('azuredns', {}) \
         .get('healthcheck', {}) \
-        .get('num_failures')
+        .get('num_failures', 3)
 
 
 def _healthcheck_interval(record):
     return record._octodns.get('azuredns', {}) \
         .get('healthcheck', {}) \
-        .get('interval')
+        .get('interval', 30)
 
 
 def _healthcheck_timeout(record):
+    default = 10 if _healthcheck_interval(record) > 10 else 9
     return record._octodns.get('azuredns', {}) \
         .get('healthcheck', {}) \
-        .get('timeout')
+        .get('timeout', default)
 
 
 def _get_monitor(record):

--- a/tests.py
+++ b/tests.py
@@ -467,9 +467,9 @@ class Test_ProfileIsMatch(TestCase):
             monitor_proto = 'HTTPS',
             monitor_port = 4443,
             monitor_path = '/_ping',
-            monitor_interval_in_seconds = None,
-            monitor_timeout_in_seconds = None,
-            monitor_tolerated_number_of_failures = None,
+            monitor_interval = None,
+            monitor_timeout = None,
+            monitor_num_failures = None,
             endpoints = 1,
             endpoint_name = 'name',
             endpoint_type = 'profile/nestedEndpoints',
@@ -487,10 +487,9 @@ class Test_ProfileIsMatch(TestCase):
                     protocol=monitor_proto,
                     port=monitor_port,
                     path=monitor_path,
-                    interval_in_seconds=monitor_interval_in_seconds,
-                    timeout_in_seconds=monitor_timeout_in_seconds,
-                    tolerated_number_of_failures=
-                    monitor_tolerated_number_of_failures,
+                    interval_in_seconds=monitor_interval,
+                    timeout_in_seconds=monitor_timeout,
+                    tolerated_number_of_failures=monitor_num_failures,
                 ),
                 endpoints=[Endpoint(
                     name=endpoint_name,
@@ -512,15 +511,15 @@ class Test_ProfileIsMatch(TestCase):
         self.assertFalse(is_match(profile(), profile(monitor_proto='HTTP')))
         self.assertFalse(is_match(
             profile(),
-            profile(monitor_interval_in_seconds=9),
+            profile(monitor_interval=9),
         ))
         self.assertFalse(is_match(
             profile(),
-            profile(monitor_timeout_in_seconds=3),
+            profile(monitor_timeout=3),
         ))
         self.assertFalse(is_match(
             profile(),
-            profile(monitor_tolerated_number_of_failures=2),
+            profile(monitor_num_failures=2),
         ))
         self.assertFalse(is_match(profile(), profile(endpoint_name='a')))
         self.assertFalse(is_match(profile(), profile(endpoint_type='b')))

--- a/tests.py
+++ b/tests.py
@@ -467,9 +467,9 @@ class Test_ProfileIsMatch(TestCase):
             monitor_proto = 'HTTPS',
             monitor_port = 4443,
             monitor_path = '/_ping',
-            monitor_interval = None,
-            monitor_timeout = None,
-            monitor_num_failures = None,
+            monitor_interval = 30,
+            monitor_timeout = 10,
+            monitor_num_failures = 3,
             endpoints = 1,
             endpoint_name = 'name',
             endpoint_type = 'profile/nestedEndpoints',
@@ -651,6 +651,9 @@ class TestAzureDnsProvider(TestCase):
         header = MonitorConfigCustomHeadersItem(name='Host',
                                                 value='foo.unit.tests')
         monitor = MonitorConfig(protocol='HTTPS', port=4443, path='/_ping',
+                                tolerated_number_of_failures=3,
+                                interval_in_seconds=30,
+                                timeout_in_seconds=10,
                                 custom_headers=[header])
         external = 'Microsoft.Network/trafficManagerProfiles/externalEndpoints'
         nested = 'Microsoft.Network/trafficManagerProfiles/nestedEndpoints'


### PR DESCRIPTION
Using `None`s causes mismatch with remote (which converts `None`s to Azure's defaults) triggering record updates. This is a fix for that.

Also simplifying the very cumbersome-to-type monitor option keys (will update README after #2 goes in EDIT: Done).