### PR TITLE
Drop retry policy from TrafficManagerClient

### DIFF
--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -562,7 +562,6 @@ class AzureProvider(BaseProvider):
                     tenant=self._dns_client_directory_id,
                 ),
                 self._dns_client_subscription_id,
-                retry_policy=self._dns_client_retry_policy
             )
         return self.__tm_client
 


### PR DESCRIPTION
Looks like `TrafficManagerManagementClient` indeed doesn't support `retry_policy` and throws an exception:

```
  File "/home/vimehta/code/playground/dynamic-dns/venv/lib/python3.8/site-packages/octodns_azure/__init__.py", line 558, in _tm_client
    self.__tm_client = TrafficManagerManagementClient(
TypeError: __init__() got an unexpected keyword argument 'retry_policy'
```

/cc @awlx #4 