### PR TITLE
Require msrestazure in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
         'azure-identity>=1.7.1',
         'azure-mgmt-dns>=8.0.0',
         'azure-mgmt-trafficmanager>=0.51.0',
+        # Remove msrestazure if Azure/azure-sdk-for-python#22732 is resolved
+        'msrestazure>=0.6.4',
         'octodns>=0.9.14',
     ),
     url='https://github.com/octodns/octodns-azure',


### PR DESCRIPTION
Require msrestazure in setup.py, to work around Azure/azure-sdk-for-python#22732

Fixes #7

👋 This is my first time editing a setup.py, I think. Please make or request changes as you see fit :bow: