### PR TITLE
Fix v0.0.2 release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.2 - 2022-01-04 - The required things
+## v0.0.2 - 2022-01-23 - The required things
 
 * Include msrestazure in install_requires to get a hidden dep covered
 


### PR DESCRIPTION
Not sure how to backport to 0.0.2 release but probably not necessary.