### PR TITLE
Remove setup.py comment added in bd56abc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'azure-identity>=1.7.1',
         'azure-mgmt-dns>=8.0.0',
         'azure-mgmt-trafficmanager>=0.51.0',
-        # Remove msrestazure if Azure/azure-sdk-for-python#22732 is resolved
         'msrestazure>=0.6.4',
         'octodns>=0.9.14',
     ),


### PR DESCRIPTION
Per https://github.com/Azure/azure-sdk-for-python/issues/22732#issuecomment-1020373147 the library that uses azure.common.credentials should require **msrestazure**:

> It is by design that azure-common does not explicitly require msrestazure.
> 
> The reason is azure.common.credentials is not always used by SDK libraries. (e.g. all track 2 libraries do not use it).
> 
> So the design is it is on the libraries who need azure.common.credentials to add requirement on msrestazure.

In this case, I think this octodns-azure provider is that library.

https://github.com/octodns/octodns-azure/blob/7ecd40ab02225bbd0d661e815d538273cb0ee933/octodns_azure/__init__.py#L10

This pull request proposes removing the comment in setup.py that marked **msrestazure** as a temporary requirement.