### PR TITLE
Rel 0.0.3 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.3 - 2022-03-04 - Honing requirements
+
+* Fix traffic manager authentication with new azure-identity
+* Improved pinning for azure python module version requirements
+
 ## v0.0.2 - 2022-01-23 - The required things
 
 * Include msrestazure in install_requires to get a hidden dep covered

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -20,7 +20,7 @@ from octodns.record import Record, Update, GeoCodes
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 
 class AzureException(ProviderException):


### PR DESCRIPTION
## v0.0.3 - 2022-03-04 - Honing requirements

* Fix traffic manager authentication with new azure-identity
* Improved pinning for azure python module version requirements

Realized that we haven't cut a release since the identity and version requirement fixes were put in place and 0.0.2 is currently broken unless manually pinned to the old azure-identity.