### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_provider_azure.py
+++ b/tests/test_provider_azure.py
@@ -682,6 +682,7 @@ class TestAzureDnsProvider(TestCase):
             'mock_directory',
             'mock_sub',
             'mock_rg',
+            strict_supports=False,
         )
 
         # Fetch the client to force it to load the creds


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957