### PR TITLE
Release 0.0.4 with changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-## v0.0.4 - 2022-??-?? - Support the root
+## v0.0.4 - 2022-11-30 - Support the root
 
-* Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
-  octodns>=0.9.16. Note that azure does not allow the removal of its own name
+* Enable `SUPPORTS_ROOT_NS` for management of root NS records. Requires
+  `octodns>=0.9.16`. Note that Azure does not allow the removal of its own name
   servers so in cases where your config doesn't include them the provider will
-  still leave them in place for azure.
+  still leave them in place for Azure.
+* Bug fixes around usage of the default value also inside pools of dynamic
+  records.
 
 ## v0.0.3 - 2022-03-04 - Honing requirements
 

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -35,7 +35,7 @@ from octodns.record import Record, Update, GeoCodes
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.3'
+__VERSION__ = '0.0.4'
 
 
 class AzureException(ProviderException):


### PR DESCRIPTION
## v0.0.4 - 2022-11-30 - Support the root

* Enable `SUPPORTS_ROOT_NS` for management of root NS records. Requires
  `octodns>=0.9.16`. Note that Azure does not allow the removal of its own name
  servers so in cases where your config doesn't include them the provider will
  still leave them in place for Azure.
* Bug fixes around usage of the default value also inside pools of dynamic
  records.

Long overdue release.