### PR TITLE
Bump certifi to 2022.12.7 due to security vuln

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ azure-identity==1.7.1
 azure-mgmt-core==1.3.2
 azure-mgmt-dns==8.0.0
 azure-mgmt-trafficmanager==1.0.0
-certifi==2022.9.24
+certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==2.1.1
 cryptography==38.0.3


### PR DESCRIPTION
/cc https://github.com/octodns/octodns-ddns/security/dependabot/2