### PR TITLE
Allow RRsets return size (top) to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ providers:
     #client_total_retries: 10
     # status_retries default 3
     #client_status_retries: 3
+    # The maximum number of record sets to return per page.
+    # https://learn.microsoft.com/en-us/rest/api/dns/record-sets/list-by-dns-zone
+    # Top default 100
+    #top: 100
 ```
 
 The first four variables above can be hidden in environment variables and octoDNS will automatically search for them in the shell. It is possible to also hard-code into the config file: eg, resource_group.

--- a/tests/test_provider_azure.py
+++ b/tests/test_provider_azure.py
@@ -925,6 +925,7 @@ class TestAzureDnsProvider(TestCase):
             'mock_directory',
             'mock_sub',
             'mock_rg',
+            'mock_top',
             strict_supports=False,
         )
 


### PR DESCRIPTION
Added the ability to modify the maximum number of record sets returned per page. Azure allows returning up to 1000 records per page. The default has been set to 100, which is the value set by Azure if not specified.