### PR TITLE
Implement Provider.list_zones for dynamic zone config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.6 - 2023-??-?? - ???
+
+* Adds Provider.list_zones to enable new dynamic zone config functionality
+
 ## v0.0.5 - 2023-07-27 - More feature support
 
 * Add support for [Azure Private DNS](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview)

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -659,6 +659,9 @@ class AzureBaseProvider(BaseProvider):
             # Else return nothing (aka false)
             return
 
+    def list_zones(self):
+        return sorted([f'{z}.' for z in self._azure_zones])
+
     def populate(self, zone, target=False, lenient=False):
         '''Required function of manager.py to collect records from zone.
 

--- a/tests/test_provider_azure.py
+++ b/tests/test_provider_azure.py
@@ -1310,6 +1310,24 @@ class TestAzureDnsProvider(TestCase):
         # This should be returning two zones since two zones are the same
         self.assertEqual(len(provider._azure_zones), 2)
 
+    def test_list_zones(self):
+        provider = self._get_provider()
+
+        zone_list = provider.dns_client.zones.list_by_resource_group
+        zone_1 = AzureZone(location='global')
+        # This is far from ideal but the
+        # zone constructor doesn't let me set it on creation
+        zone_1.name = "other.thing"
+        zone_2 = AzureZone(location='global')
+        # This is far from ideal but the
+        # zone constructor doesn't let me set it on creation
+        zone_2.name = "alpha.com"
+        zone_list.return_value = [zone_1, zone_2, zone_1]
+
+        self.assertEqual(
+            [f'{zone_2.name}.', f'{zone_1.name}.'], provider.list_zones()
+        )
+
     def test_bad_zone_response(self):
         provider = self._get_provider()
 


### PR DESCRIPTION
Adds Provider.list_zones method to allow using Ns1Provider as a source of dynamic zone configs.

/cc https://github.com/octodns/octodns/pull/1026 for base functionality that will utilize this