### PR TITLE
Allow AzureCliCredential method for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.8 - 2024-??-?? - 
+
+* Support for authenticating via the CLI/AzureCliCredential
+
 ## v0.0.7 - 2023-11-14 - Maintenance release
 
 * Several improvements to the maintenance mechanisms for this package

--- a/README.md
+++ b/README.md
@@ -36,13 +36,21 @@ octodns-azure==0.0.1
 providers:
   azure:
     class: octodns_azure.AzureProvider
-    # Current support of authentication of access to Azure services only
-    # includes using a Service Principal:
+    # Current support of authentication of access to Azure services is
+    # either using a Service Principal or deferring to an already authenticated
+    # `az` CLI instance.
     # https://docs.microsoft.com/en-us/azure/azure-resource-manager/
     #                        resource-group-create-service-principal-portal
-    # The Azure Active Directory Application ID (aka client ID):
+    # https://learn.microsoft.com/en-us/cli/azure/
+    #
+    # The authentication method, either 'client_secret' or 'cli'. This is
+    # 'client_secret' by default
+    client_credential_method: 'client_secret'
+    # The Azure Active Directory Application ID (aka client ID). Required for
+    # the 'client_secret' credential method.
     client_id: env/AZURE_APPLICATION_ID
-    # Authentication Key Value: (note this should be secret)
+    # Authentication Key Value: (note this should be secret). Required for the
+    # 'client_secret' credential method
     key: env/AZURE_AUTHENTICATION_KEY
     # Directory ID (aka tenant ID):
     directory_id: env/AZURE_DIRECTORY_ID
@@ -71,7 +79,7 @@ providers:
     #base_url: https://management.azure.com
 ```
 
-The first four variables above can be hidden in environment variables and octoDNS will automatically search for them in the shell. It is possible to also hard-code into the config file: eg, resource_group.
+The variables starting with `env/` above can be hidden in environment variables and octoDNS will automatically search for them in the shell. It is possible to also hard-code into the config file: eg, resource_group.
 
 For management of DNS zones on [Azure Private DNS](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview), use `class: octodns_azure.AzurePrivateProvider`. Note that this provider does not support dynamic records or root NS records.
 

--- a/tests/test_provider_azure.py
+++ b/tests/test_provider_azure.py
@@ -5,6 +5,7 @@
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
+from azure.identity import AzureCliCredential
 from azure.mgmt.dns.models import (
     AaaaRecord,
     ARecord,
@@ -931,54 +932,6 @@ class TestAzureDnsProvider(TestCase):
             'mock_id',
             'mock_sub',
             'mock_rg',
-            directory_id='mock_directory',
-            client_id='mock_client',
-            key='mock_key',
-            strict_supports=False,
-        )
-
-        # Fetch the client to force it to load the creds
-        provider.dns_client
-
-        # set critical functions to return properly
-        tm_list = provider._tm_client.profiles.list_by_resource_group
-        tm_list.return_value = []
-        tm_sync = provider._tm_client.profiles.create_or_update
-
-        def side_effect(rg, name, profile):
-            return Profile(
-                id=profile.id,
-                name=profile.name,
-                traffic_routing_method=profile.traffic_routing_method,
-                dns_config=profile.dns_config,
-                monitor_config=profile.monitor_config,
-                endpoints=profile.endpoints,
-            )
-
-        tm_sync.side_effect = side_effect
-
-        return provider
-
-    @patch('octodns_azure.TrafficManagerManagementClient')
-    @patch('octodns_azure.DnsManagementClient')
-    @patch('octodns_azure.ClientSecretCredential')
-    def _get_cli_provider(self, mock_css, mock_client, mock_tm_client):
-        '''Returns a mock AzureProvider object to use in testing.
-
-        :param mock_spc: placeholder
-        :type  mock_spc: str
-        :param mock_client: placeholder
-        :type  mock_client: str
-        :param mock_tm_client: placeholder
-        :type  mock_tm_client: str
-
-        :type return: AzureProvider
-        '''
-        provider = AzureProvider(
-            'mock_id',
-            'mock_sub',
-            'mock_rg',
-            client_credential_method='cli',
             directory_id='mock_directory',
             client_id='mock_client',
             key='mock_key',
@@ -4200,20 +4153,20 @@ class TestAzureDnsProvider(TestCase):
         # same object, no copy
         self.assertEqual(id(zone), id(ret))
 
-    def test_cli(self):
-        provider = self._get_cli_provider()
+    def test_cli_provider(self):
+        '''Tests that the AzureProvider is created correctly'''
+        provider = AzureProvider(
+            'mock_id',
+            'mock_sub',
+            'mock_rg',
+            client_credential_method='cli',
+            directory_id='mock_directory',
+            client_id='mock_client',
+            key='mock_key',
+            strict_supports=False,
+        )
 
-        # setup traffic manager profiles
-        tm_list = provider._tm_client.profiles.list_by_resource_group
-        tm_list.return_value = self._get_tm_profiles(provider)
-
-        # setup zone with dynamic record
-        zone = Zone(name='unit.tests.', sub_zones=[])
-        record = self._get_dynamic_record(zone)
-        zone.add_record(record)
-
-        # return everything
-        return provider, zone, record
+        self.assertIsInstance(provider._client_credential, AzureCliCredential)
 
     def test_no_provider(self):
         provider = AzureProvider(


### PR DESCRIPTION
This will allow e.g. running octodns-azure inside a GitHub Action with
[federated credentials](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#use-the-azure-login-action-with-openid-connect).

The user needs to log in with e.g. `azure/login@v1`. octodns-azure, when
configured with the `cli` `client_credential_method` will then use the
`az` CLI tool to procure a login token/credential without the need for
hard-coded credentials.

This code has been written to ensure full backwards compatibility with
existing configurations.
