### PR TITLE
Bump up main version to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## v0.0.8 - 2024-??-?? - 
+## v0.0.8 - 2024-06-27 - More feature support
 
 * Support for authenticating via the CLI/AzureCliCredential
 * Validate that healthcheck protocol is supported (HTTP, HTTPS, TCP)
+* Upgrade `azure-identity>= 1.6.1` to fix security vulnerabilities
 
 ## v0.0.7 - 2023-11-14 - Maintenance release
 

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -42,7 +42,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.7'
+__version__ = __VERSION__ = '0.0.8'
 
 
 class AzureException(ProviderException):


### PR DESCRIPTION
As a follow up of https://github.com/octodns/octodns-azure/pull/92

bump up the version so we can consume the new version of octodns.