### PR TITLE
Disregard always_serve for disabled endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.10 - 2024-??-?? - ????
+
+* Don't attempt to change 'always_serve' flag when Traffic manager's endpoint
+  is disabled.
+
 ## v0.0.9 - 2024-08-22 - Retry until your hearts content
 
 * Add support for fully managing/configuring the client retry policy & fix

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -473,7 +473,13 @@ def _profile_is_match(have, desired):
             have_endpoint.name != desired_endpoint.name
             or have_endpoint.type != desired_endpoint.type
             or have_status != desired_status
-            or have_always_serve != desired_always_serve
+        ):
+            return false(have_endpoint, desired_endpoint, have.name)
+
+        # check always_serve only if endpoint is enabled, otherwise it doesn't matter
+        if (
+            have_status == EndpointStatus.ENABLED
+            and have_always_serve != desired_always_serve
         ):
             return false(have_endpoint, desired_endpoint, have.name)
 

--- a/tests/test_provider_azure.py
+++ b/tests/test_provider_azure.py
@@ -880,6 +880,32 @@ class Test_ProfileIsMatch(TestCase):
                 profile(), profile(endpoint_status=EndpointStatus.DISABLED)
             )
         )
+        # compare always_serve if endpoint is enabled
+        self.assertFalse(
+            is_match(
+                profile(
+                    endpoint_status=EndpointStatus.ENABLED,
+                    always_serve=AlwaysServe.ENABLED,
+                ),
+                profile(
+                    endpoint_status=EndpointStatus.ENABLED,
+                    always_serve=AlwaysServe.DISABLED,
+                ),
+            )
+        )
+        # always_serve shouldn't matter if endpoint is disabled
+        self.assertTrue(
+            is_match(
+                profile(
+                    endpoint_status=EndpointStatus.DISABLED,
+                    always_serve=AlwaysServe.ENABLED,
+                ),
+                profile(
+                    endpoint_status=EndpointStatus.DISABLED,
+                    always_serve=AlwaysServe.DISABLED,
+                ),
+            )
+        )
         self.assertFalse(
             is_match(profile(endpoint_type='b'), profile(endpoint_type='b'))
         )


### PR DESCRIPTION
Ran into a situation where independent tooling was manipulating these flags in an incompatible way with octodns-azure. Led to this improvement where we shouldn't really care about `always_serve` when endpoint is disabled. We say so [here](https://github.com/octodns/octodns-azure/blob/v0.0.9/octodns_azure/__init__.py#L538) yet assert a particular `always_serve` value [here](https://github.com/octodns/octodns-azure/blob/v0.0.9/octodns_azure/__init__.py#L549). This PR effectively makes `always_serve` noop when `status` is disabled.