### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.10 - 2024-??-?? - ????
+## v1.0.0 - 2025-04-29 - Long overdue 1.x
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
 * Don't attempt to change 'always_serve' flag when Traffic manager's endpoint

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -42,7 +42,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.9'
+__version__ = __VERSION__ = '1.0.0'
 
 
 class AzureException(ProviderException):


### PR DESCRIPTION
## v1.0.0 - 2025-04-29 - Long overdue 1.x

* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
* Don't attempt to change 'always_serve' flag when Traffic manager's endpoint
  is disabled.