### PR TITLE
fix(credential): fix credential issue on CN tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.? - 2025-??-?? - ???
+
+* Fix support for CN tenant
+
 ## v1.0.0 - 2025-04-29 - Long overdue 1.x
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -989,7 +989,7 @@ class AzureProvider(AzureBaseProvider):
         if self._dns_client is None:
             self._dns_client = DnsManagementClient(
                 credential=self._client_credential,
-                credential_scopes=[self._base_url],
+                credential_scopes=[self._base_url + "/.default"],
                 subscription_id=self._client_subscription_id,
                 retry_policy=self._dns_client_retry_policy,
                 base_url=self._base_url,

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -989,6 +989,7 @@ class AzureProvider(AzureBaseProvider):
         if self._dns_client is None:
             self._dns_client = DnsManagementClient(
                 credential=self._client_credential,
+                credential_scopes=[self._base_url],
                 subscription_id=self._client_subscription_id,
                 retry_policy=self._dns_client_retry_policy,
                 base_url=self._base_url,
@@ -2017,6 +2018,7 @@ class AzurePrivateProvider(AzureBaseProvider):
         if self._dns_client is None:
             self._dns_client = PrivateDnsManagementClient(
                 credential=self._client_credential,
+                credential_scopes=[self._base_url + "/.default"],
                 subscription_id=self._client_subscription_id,
                 base_url=self._base_url,
             )


### PR DESCRIPTION
# Fix credential issue on CN azure context

This PR solves authentication issue on a chinese tenant. Following [this issue](https://github.com/octodns/octodns-azure/issues/102). 

As of now, when you try to use octodns on a CN context you will end up with this error : 
```
octo-sync --config-file=public-file.yaml
ERROR: AADSTS500011: The resource principal named https://management.azure.com was not found in the tenant named

octo-sync --config-file=private-file.yaml
azure.core.exceptions.ClientAuthenticationError: Authentication failed: AADSTS500011: The resource principal named https://management.azure.com was not found in the tenant named
```
even though on both files, the following settings have been applied :
```
authority: https://login.partner.microsoftonline.cn
base_url: https://management.chinacloudapi.cn
```

After the fix, both synchronization are working properly. 

```
2025-05-19T09:20:40  [264762031934928] DEBUG msal.token_cache event={
    "client_id": "REDACTED",
    "data": {
        "claims": null,
        "scope": [
            "https://management.chinacloudapi.cn/.default"
        ]
    },
    "environment": "login.partner.microsoftonline.cn",
    "grant_type": "client_credentials",
    "params": null,
    "response": {
        "access_token": "********",
        "expires_in": 3599,
        "ext_expires_in": 3599,
        "token_type": "Bearer"
    },
    "scope": [
        "https://management.chinacloudapi.cn/.default"
    ],
    "token_endpoint": "https://login.partner.microsoftonline.cn/REDACTED/oauth2/v2.0/token"
}
2025-05-19T09:20:40  [264762031934928] INFO  azure.identity._internal.get_token_mixin ClientSecretCredential.get_token_info succeeded
```