### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/042774049a1948d3b19c91555be76953.md
+++ b/.changelog/042774049a1948d3b19c91555be76953.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/06c1ee2434b6440cb427f438502e7b5f.md
+++ b/.changelog/06c1ee2434b6440cb427f438502e7b5f.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/1d7c7dcc36ef4020a8ba805809741bfa.md
+++ b/.changelog/1d7c7dcc36ef4020a8ba805809741bfa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/1d946a730417406fbc35e7d1ce22efc3.md
+++ b/.changelog/1d946a730417406fbc35e7d1ce22efc3.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/2a7025e470634b4ab94929d7f139f373.md
+++ b/.changelog/2a7025e470634b4ab94929d7f139f373.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in all the latest template changes

--- a/.changelog/2b24bc650e564f9180375f62758af8d8.md
+++ b/.changelog/2b24bc650e564f9180375f62758af8d8.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/7d4e4f3259df495cb4fd927f2dc19a84.md
+++ b/.changelog/7d4e4f3259df495cb4fd927f2dc19a84.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Speed up populate by skipping _check_zone and catching missing-zone errors from _zone_records

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/84041df3ec3346e294348ad3d706c537.md
+++ b/.changelog/84041df3ec3346e294348ad3d706c537.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements-dev.txt requirements.txt

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/925917155d3d4bbda43ccbf93ed40923.md
+++ b/.changelog/925917155d3d4bbda43ccbf93ed40923.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/9a12a5a27ffe4d4f904e607b3ba856c7.md
+++ b/.changelog/9a12a5a27ffe4d4f904e607b3ba856c7.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/bdc60d51f46b47798783910f850cea95.md
+++ b/.changelog/bdc60d51f46b47798783910f850cea95.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Fix support for CN tenant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* Fix support for CN tenant - [#108](https://github.com/octodns/octodns-azure/pull/108)
+
+Patch:
+* Speed up populate by skipping _check_zone and catching missing-zone errors from _zone_records - [#120](https://github.com/octodns/octodns-azure/pull/120)
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#107](https://github.com/octodns/octodns-azure/pull/107)
+
 ## v1.0.0 - 2025-04-29 - Long overdue 1.x
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -43,7 +43,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.1.0'
 
 
 class AzureException(ProviderException):


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* Fix support for CN tenant - [#108](https://github.com/octodns/octodns-azure/pull/108)

Patch:
* Speed up populate by skipping _check_zone and catching missing-zone errors from _zone_records - [#120](https://github.com/octodns/octodns-azure/pull/120)
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#107](https://github.com/octodns/octodns-azure/pull/107)

