### PR TITLE
Fix populate when Azure DNS zone does not exist

### DIFF
--- a/.changelog/bbe61a257f3b45fb3b269b777e642718.md
+++ b/.changelog/bbe61a257f3b45fb3b269b777e642718.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix populate for missing Azure DNS zones when record_sets list returns a lazy pager (regression from 1.1.0)

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -768,10 +768,10 @@ class AzureBaseProvider(BaseProvider):
         zone_name = zone.name[:-1]
 
         try:
-            exists = True
             rg = self._resource_group
             top = self._dns_client_top
-            azrecords = self._zone_records(rg, zone_name, top)
+            azrecords = list(self._zone_records(rg, zone_name, top))
+            exists = True
         except ResourceNotFoundError:
             exists = False
 

--- a/tests/test_provider_azure.py
+++ b/tests/test_provider_azure.py
@@ -52,6 +52,17 @@ from octodns_azure import (
     _root_traffic_manager_name,
 )
 
+
+class _DeferredResourceNotFoundPager:
+    """Pager that raises ResourceNotFoundError on iteration (like azure ItemPaged)."""
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise ResourceNotFoundError('zone missing')
+
+
 zone_public = Zone(name='unit.tests.', sub_zones=[])
 octo_records = []
 octo_records.append(
@@ -4052,14 +4063,13 @@ class TestAzureDnsProvider(TestCase):
         rs.append(recordSet)
 
         record_list = provider.dns_client.record_sets.list_by_dns_zone
-        record_list.side_effect = ResourceNotFoundError(
-            'unit3.test missing in mock_rg'
-        )
+        record_list.return_value = _DeferredResourceNotFoundPager()
 
-        exists = provider.populate(Zone('unit3.test.', []))
+        zone = Zone('unit3.test.', [])
+        exists = provider.populate(zone)
         self.assertFalse(exists)
 
-        self.assertEqual(len(zone_public.records), 0)
+        self.assertEqual(len(zone.records), 0)
 
     def test_populate_caches_root_ns(self):
         provider = self._get_provider()
@@ -4579,11 +4589,10 @@ class TestPrivateAzureDnsProvider(TestCase):
         rs.append(recordSet)
 
         record_list = provider.dns_client.record_sets.list
-        record_list.side_effect = ResourceNotFoundError(
-            'unit3.test missing in mock_rg'
-        )
+        record_list.return_value = _DeferredResourceNotFoundPager()
 
-        exists = provider.populate(Zone('unit3.test.', []))
+        zone = Zone('unit3.test.', [])
+        exists = provider.populate(zone)
         self.assertFalse(exists)
 
-        self.assertEqual(len(zone_private.records), 0)
+        self.assertEqual(len(zone.records), 0)


### PR DESCRIPTION
Hey folks! 👋 Hope this is a useful contribution — happy to tweak anything.

Fixes #123

## What happened

The intent of #120 was great — skip the extra `_check_zone()` round-trip and catch missing zones directly from the list call. The tricky bit is that `record_sets.list_by_dns_zone` returns a lazy `azure.core.paging.ItemPaged`, so no HTTP request happens when you call it — the 404 only fires on the **first iteration**. That means the `ResourceNotFoundError` escapes the `try/except` and crashes plan instead of gracefully returning `exists=False`.

Here's the sequence:

```python
# 1. This returns a lazy pager — no HTTP, no exception
azrecords = self._zone_records(rg, zone_name, top)
# 2. exists = True is now set and we exit the try block cleanly
# 3. The HTTP call (and the 404) happens here, outside the try
for azrecord in azrecords:
    ...
```

The test added in #120 used `side_effect=ResourceNotFoundError(...)` on the mock, which makes the exception fire synchronously on call — so it was caught inside the `try` and the test passed. But the real SDK defers the error to iteration, so production still breaks.

## Fix

Materialise the pager inside the `try` with `list()`, so the deferred HTTP call happens where it can be caught:

```python
try:
    rg = self._resource_group
    top = self._dns_client_top
    azrecords = list(self._zone_records(rg, zone_name, top))  # HTTP happens here now
    exists = True
except ResourceNotFoundError:
    exists = False
```

This covers all three cases correctly:
- Missing zone → 404 on `list()` → caught → `exists=False`
- Empty existing zone → `list()` returns `[]` → `exists=True`, loop is a no-op
- Non-empty zone → works as before

## Tests

Updated `test_check_zone_no_create` (public + private) to use a `_DeferredResourceNotFoundPager` helper that raises on `__next__` rather than on call, which more accurately mirrors the SDK's lazy behaviour:

```python
class _DeferredResourceNotFoundPager:
    """Raises ResourceNotFoundError on iteration, like a real azure ItemPaged."""
    def __iter__(self): return self
    def __next__(self): raise ResourceNotFoundError('zone missing')
```

Also fixed a small pre-existing assertion quirk in those tests — they were comparing `len(zone_public.records)` (module-level zone) instead of the local zone returned from `populate()`.

```
pytest --disable-network tests/test_provider_azure.py -k test_check_zone_no_create
2 passed
```

Full test suite and `./script/lint` both pass.

---

Happy to switch to iterating inside the `try` if you'd prefer to keep the streaming behaviour, or to make any other changes. Thanks again for all the work on this provider! 🙏
