### PR TITLE
Version 1.1.1 bump & changelog update

### DIFF
--- a/.changelog/bbe61a257f3b45fb3b269b777e642718.md
+++ b/.changelog/bbe61a257f3b45fb3b269b777e642718.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix populate for missing Azure DNS zones when record_sets list returns a lazy pager (regression from 1.1.0)

--- a/.changelog/e7ee57a2a7a74ed38a2f244ecb295664.md
+++ b/.changelog/e7ee57a2a7a74ed38a2f244ecb295664.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1 - 2026-05-22
+
+Patch:
+* Fix populate for missing Azure DNS zones when record_sets list returns a lazy pager (regression from 1.1.0) - [#124](https://github.com/octodns/octodns-azure/pull/124)
+
 ## 1.1.0 - 2026-04-03
 
 Minor:

--- a/octodns_azure/__init__.py
+++ b/octodns_azure/__init__.py
@@ -43,7 +43,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import GeoCodes, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.1.0'
+__version__ = __VERSION__ = '1.1.1'
 
 
 class AzureException(ProviderException):


### PR DESCRIPTION
## 1.1.1 - 2026-05-22

Patch:
* Fix populate for missing Azure DNS zones when record_sets list returns a lazy pager (regression from 1.1.0) - [#124](https://github.com/octodns/octodns-azure/pull/124)

